### PR TITLE
chore: Update docker compose dev environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.DS_Store
+.git*

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,5 @@ RUN --mount=target=Gemfile,src=Gemfile \
 ENTRYPOINT ["jekyll"]
 
 CMD ["serve"]
+
+COPY . .

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,15 @@
+services:
+  jekyll:
+    build: .
+    command: serve --livereload
+    ports:
+      - "4000:4000"
+    develop:
+      watch:
+        - action: sync
+          path: .
+          target: /srv/jekyll
+          ignore:
+            - _site/
+        - action: rebuild
+          path: Gemfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,0 @@
-version: '3'
-services:
-  jekyll:
-    build: .
-    command: serve --livereload
-    ports:
-      - "4000:4000"
-    volumes:
-      - .:/srv/jekyll/


### PR DESCRIPTION
Get rid of some warnings from deprecated compose usage.

Rename docker-compose.yml -> compose.yml.

Use [file watch](https://docs.docker.com/compose/file-watch) instead of bind mounts.